### PR TITLE
Update TaskLogView.vue

### DIFF
--- a/web/src/components/TaskLogView.vue
+++ b/web/src/components/TaskLogView.vue
@@ -113,7 +113,7 @@
 }
 
 .task-log-records {
-  background: black;
+  background: #404040;
   color: white;
   height: calc(100vh - 280px);
   overflow: auto;


### PR DESCRIPTION
With the current background color, you can't see the 'task path' in Ansible that has a font color of black.

A hex value of #404040 seems to strike the balance of being able to see the darker colors (black and blue) AND the lighter/bright colors (green and red) equally well (at least on my two monitors). 

Current background-color:
![000000_bg-color](https://github.com/user-attachments/assets/3b32a964-23bc-4838-9dc4-629b683fd62f)

Proposed background-color:
![404040_bg-color](https://github.com/user-attachments/assets/dee818b4-09e7-493c-858a-ea806feb3c86)

I'm not sure what would be involved to make this a settings option (or at least a config at runtime), but hard coding it is easy enough. I haven't tested this outside of Ansible